### PR TITLE
feat: enable ext communication helper

### DIFF
--- a/src/getExtension/getExtension.ts
+++ b/src/getExtension/getExtension.ts
@@ -24,3 +24,24 @@ export function getExtensions(): Promise<
 
   return documentReadyPromise(() => apiWindow.kilt)
 }
+
+/**
+ * This function enables the communication with extensions supporting the Credential API.
+ *
+ * The `meta` property of `window.kilt` is set according to the Credential API.
+ * After this is done an event is dispatched to notify all extensions that they should inject themselves now.
+ */
+export function initializeKiltExtensionAPI() {
+  apiWindow.kilt = apiWindow.kilt || {}
+
+  Object.defineProperty(apiWindow.kilt, 'meta', {
+    value: {
+      versions: {
+        credentials: '3.0'
+      }
+    },
+    enumerable: false
+  })
+
+  apiWindow.dispatchEvent(new CustomEvent('kilt-dapp#initialized'))
+}


### PR DESCRIPTION
## related KILTprotocol/ticket/issues/2126

This PR adds a helper to signal the extension that the DApp supports the credential API.

The Credential API version is hard coded inside this library as it is expected that downstream projects support exactly the version that is supported by this library. If this library updates the Credential API version all downstream project will be required to update their code to support the new version.

### Support for possible other APIs

If there are new APIs added to the wallets this method can be extended in the following way: 

```ts
export function initializeKiltExtensionAPI(options: {
  credentialApi: boolean,
  newApi: boolean,
} = {
  credentialApi: true,
  newApi: false,
})
```

This would be a non breaking change.