### PR TITLE
feat!: getExtensions isn't a promise

### DIFF
--- a/src/getExtension/getExtension.ts
+++ b/src/getExtension/getExtension.ts
@@ -12,13 +12,12 @@ const apiWindow = window as Window & ApiWindow
  *
  * Note that this method only returns the extensions that are initialized at the time when this function is called.
  * If an extension injects itself only after this function is called, it will not be contained in the returned extensions.
- * @returns an object containing extensions
+ *
+ * @returns an array of extensions
  */
 export function getExtensions(): Array<InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>> {
 
-  // Copy all extensions into a new object since the caller should be allowed to change the object
-  // without changing the underlying extension object.
-  // This also intentionally strips away the `meta` property.
+  // Remove the meta object and return a list of extension objects
   return Object.values(apiWindow.kilt)
 }
 

--- a/src/getExtension/getExtension.ts
+++ b/src/getExtension/getExtension.ts
@@ -7,22 +7,18 @@ import {
 
 const apiWindow = window as Window & ApiWindow
 
-function documentReadyPromise<T>(creator: () => T): Promise<T> {
-  return new Promise((resolve): void => {
-    if (document.readyState === 'complete') {
-      resolve(creator())
-    } else {
-      window.addEventListener('load', () => resolve(creator()))
-    }
-  })
-}
+/**
+ * Get all extensions that are currently initialized and support the Credential API.
+ * 
+ * Note that this method only returns the extensions that are initialized at the time when this function is called.
+ * If an extension injects itself only after this function is called, it will not be contained in the returned extensions.
+ * @returns an object containing extensions
+ */
+export function getExtensions(): Record<string, InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>> {
 
-export function getExtensions(): Promise<
-  Record<string, InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>>
-> {
-  apiWindow.kilt = apiWindow.kilt || {}
-
-  return documentReadyPromise(() => apiWindow.kilt)
+  // copy all extensions into a new object since the caller should be allowed to change the object
+  // without changing the underlying extension object.
+  return { ...apiWindow.kilt }
 }
 
 /**

--- a/src/getExtension/getExtension.ts
+++ b/src/getExtension/getExtension.ts
@@ -9,16 +9,17 @@ const apiWindow = window as Window & ApiWindow
 
 /**
  * Get all extensions that are currently initialized and support the Credential API.
- * 
+ *
  * Note that this method only returns the extensions that are initialized at the time when this function is called.
  * If an extension injects itself only after this function is called, it will not be contained in the returned extensions.
  * @returns an object containing extensions
  */
-export function getExtensions(): Record<string, InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>> {
+export function getExtensions(): Array<InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>> {
 
-  // copy all extensions into a new object since the caller should be allowed to change the object
+  // Copy all extensions into a new object since the caller should be allowed to change the object
   // without changing the underlying extension object.
-  return { ...apiWindow.kilt }
+  // This also intentionally strips away the `meta` property.
+  return Object.values(apiWindow.kilt)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { getExtensions } from './getExtension/getExtension'
+export { getExtensions, initializeKiltExtensionAPI } from './getExtension/getExtension'
 import * as WellKnownDidConfiguration from './wellKnownDidConfiguration/wellKnownDidConfiguration'
 import * as Types from './types/types'
-export { getExtensions, WellKnownDidConfiguration }
+export { WellKnownDidConfiguration }
 export type { Types }


### PR DESCRIPTION
# related https://github.com/KILTprotocol/ticket/issues/2126

This PR changes the `getExtension` function.

* remove any side effects (setting the `window.kilt` property)
* make it synchronous (makes it more ergonomic to use since it's usable in both sync and async environments)

## Future additions

we already dispatch the `kilt-dapp#initialized` even though it's not part of the Credential API 3.0.

Once the events are part of the credential API we should include a [function for listening to new extensions](https://github.com/KILTprotocol/kilt-extension-api/pull/13).