### PR TITLE
feat: watch for extensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+[*]
+end_of_line=lf
+charset=utf-8
+trim_trailing_whitespace=true
+max_line_length=120
+insert_final_newline=true

--- a/src/getExtension/getExtension.ts
+++ b/src/getExtension/getExtension.ts
@@ -9,7 +9,7 @@ const apiWindow = window as Window & ApiWindow
 
 /**
  * Get all extensions that are currently initialized and support the Credential API.
- * 
+ *
  * Note that this method only returns the extensions that are initialized at the time when this function is called.
  * If an extension injects itself only after this function is called, it will not be contained in the returned extensions.
  * @returns an object containing extensions
@@ -19,6 +19,28 @@ export function getExtensions(): Record<string, InjectedWindowProvider<PubSubSes
   // copy all extensions into a new object since the caller should be allowed to change the object
   // without changing the underlying extension object.
   return { ...apiWindow.kilt }
+}
+
+/**
+ * Watch for new extensions that get injected.
+ *
+ * Each time an extension has injected itself, it will dispatch an event.
+ * This function calls the provided callback with all available extensions when such an event is received.
+ *
+ * NOTE: Use the returned cleanup function to remove the event listener when the callback is not needed anymore.
+ *
+ * @param callback Callback that gets called each time a new extension is injected.
+ * @returns Cleanup function which removes the listener for new extensions.
+ */
+export function watchExtensions(callback: (extensions: Record<string, InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>>) => void): () => void {
+  function handler() {
+    callback(getExtensions())
+  }
+
+  window.addEventListener('kilt-extension#initialized', handler)
+  return () => {
+    window.removeEventListener('kilt-extension#initialized', handler)
+  }
 }
 
 /**

--- a/src/getExtension/getExtension.ts
+++ b/src/getExtension/getExtension.ts
@@ -16,10 +16,13 @@ const apiWindow = window as Window & ApiWindow
  */
 export function getExtensions(): Record<string, InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>> {
 
-  // copy all extensions into a new object since the caller should be allowed to change the object
+  // Copy all extensions into a new object since the caller should be allowed to change the object
   // without changing the underlying extension object.
+  // This also intentionally strips away the `meta` property.
   return { ...apiWindow.kilt }
 }
+
+export type WatchExtensionsCallback = (extensions: Record<string, InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>>) => void
 
 /**
  * Watch for new extensions that get injected.
@@ -32,7 +35,7 @@ export function getExtensions(): Record<string, InjectedWindowProvider<PubSubSes
  * @param callback Callback that gets called each time a new extension is injected.
  * @returns Cleanup function which removes the listener for new extensions.
  */
-export function watchExtensions(callback: (extensions: Record<string, InjectedWindowProvider<PubSubSessionV1 | PubSubSessionV2>>) => void): () => void {
+export function watchExtensions(callback: WatchExtensionsCallback): () => void {
   function handler() {
     callback(getExtensions())
   }


### PR DESCRIPTION
# related https://github.com/KILTprotocol/ticket/issues/2126

Adds a function to listen for new extensions.
This can get merged once the Credential API supports these events.