### PR TITLE
feat: prepack script to allow github installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json && echo '{\"type\": \"module\"}' > esm/package.json",
     "clean": "exec git clean -xf -e 'node_modules' '*'",
-    "test": "jest test --no-cache --forceExit"
+    "test": "jest test --no-cache --forceExit",
+    "prepack": "yarn build"
   },
   "dependencies": {
     "@kiltprotocol/sdk-js": "^0.34.0",


### PR DESCRIPTION
Adds a `prepack` script to build the package, which is called by yarn 2+ if you install the package from the GitHub source (https://yarnpkg.com/advanced/lifecycle-scripts/#prepack-and-postpack).
After this is merged, you can directly install unreleased versions of this package to your local (yarn 2+) projects, using e.g.
```bash
yarn add @kiltprotocol/kilt-extension-api@KILTprotocol/kilt-extension-api
```

## How to test:
- Create a new project using yarn 2 / yarn 3 as package manager
- Install the extension library from this branch, using `yarn add @kiltprotocol/kilt-extension-api@KILTprotocol/kilt-extension-api#rf-prepack-script`
- Try running the cli, e.g. using `yarn createDidConfig --help`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
