### PR TITLE
chore: update license

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,10 +9,11 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "license-header"],
   "rules": {
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "single"],
-    "semi": ["error", "never"]
+    "semi": ["error", "never"],
+    "license-header/header": ["error", "./license-header.js"]
   }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
-Copyright (c) 2022-2023, BOTLabs GmbH
+Copyright (c) 2018-2023, Built on KILT
 All rights reserved.
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-3. All advertising materials mentioning features or use of this software must display the following acknowledgement: This product includes software developed by the BOTLabs GmbH.
-4. Neither the name of the BOTLabs GmbH nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. All advertising materials mentioning features or use of this software must display the following acknowledgement: Built on KILT.
+4. Neither the name of KILT nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY BOTLABS GMBH  ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BOTLABS GMBH BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/license-header.js
+++ b/license-header.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */

--- a/package.json
+++ b/package.json
@@ -74,14 +74,15 @@
     "@typescript-eslint/parser": "^5.33.0",
     "eslint": ">=8.14.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-license-header": "^0.6.0",
     "jest": "^28.0.0",
+    "prettier": "^3.0.1",
     "react": "^18.2.0",
     "testcontainers": "^9.5.0",
     "ts-jest": "^28.0.8",
     "ts-jest-resolver": "^2.0.1",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4",
-    "prettier": "^3.0.1"
+    "typescript": "^4.7.4"
   },
   "bin": {
     "createDidConfig": "./cli/createDidConfig.js"

--- a/src/cli/createDidConfig.ts
+++ b/src/cli/createDidConfig.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/getExtension/index.ts
+++ b/src/getExtension/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import type { ApiWindow, InjectedWindowProvider, PubSubSessionV1, PubSubSessionV2 } from '../types/index.js'
 
 // cross-environment reference to global object (aka 'window' in browser environments)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export { getExtensions, watchExtensions, initializeKiltExtensionAPI } from './getExtension/index.js'

--- a/src/messaging/CredentialApiMessageType.ts
+++ b/src/messaging/CredentialApiMessageType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/messaging/Error.ts
+++ b/src/messaging/Error.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/messaging/Message.test.ts
+++ b/src/messaging/Message.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 /**

--- a/src/messaging/MessageEnvelope.ts
+++ b/src/messaging/MessageEnvelope.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/messaging/interface/attestation/Attestation.test.ts
+++ b/src/messaging/interface/attestation/Attestation.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
   CType,

--- a/src/messaging/interface/attestation/index.ts
+++ b/src/messaging/interface/attestation/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * from './request.js'
 export * from './response.js'

--- a/src/messaging/interface/attestation/request.ts
+++ b/src/messaging/interface/attestation/request.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { DidResolveKey, IAttestation, KiltKeyringPair } from '@kiltprotocol/types'
 import { Attestation, Did, ConfigService } from '@kiltprotocol/sdk-js'
 

--- a/src/messaging/interface/attestation/response.ts
+++ b/src/messaging/interface/attestation/response.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { DidResolveKey, ICredential, IEncryptedMessage } from '@kiltprotocol/types'
 import { Attestation, Credential, Did } from '@kiltprotocol/sdk-js'
 

--- a/src/messaging/interface/index.ts
+++ b/src/messaging/interface/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * from './attestation/index.js'
 export * from './misc/index.js'
 export * from './session/index.js'

--- a/src/messaging/interface/misc/index.ts
+++ b/src/messaging/interface/misc/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { Did } from '@kiltprotocol/sdk-js'
 
 import { IEncryptedMessage, IError, IReject, ISession } from '../../../types/index.js'

--- a/src/messaging/interface/session/Session.test.ts
+++ b/src/messaging/interface/session/Session.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { Did, DidDocument, DidKey, DidResourceUri, ResolvedDidKey, init } from '@kiltprotocol/sdk-js'
 
 import {

--- a/src/messaging/interface/session/index.ts
+++ b/src/messaging/interface/session/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * from './request.js'
 export * from './response.js'

--- a/src/messaging/interface/session/request.ts
+++ b/src/messaging/interface/session/request.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { DidDocument, DidResolveKey, DidResourceUri, SignCallback } from '@kiltprotocol/types'
 import { Did } from '@kiltprotocol/sdk-js'
 import { randomAsHex } from '@polkadot/util-crypto'

--- a/src/messaging/interface/session/response.ts
+++ b/src/messaging/interface/session/response.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import {
   DidResourceUri,
   DidDocument,

--- a/src/messaging/interface/verifier/Verifier.test.ts
+++ b/src/messaging/interface/verifier/Verifier.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
   Did,

--- a/src/messaging/interface/verifier/index.ts
+++ b/src/messaging/interface/verifier/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * from './request.js'
 export * from './response.js'

--- a/src/messaging/interface/verifier/request.ts
+++ b/src/messaging/interface/verifier/request.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { randomAsHex } from '@polkadot/util-crypto'
 import { CTypeHash, DidResolveKey, DidUri } from '@kiltprotocol/types'
 import { CType, Credential, Did } from '@kiltprotocol/sdk-js'

--- a/src/messaging/interface/verifier/response.ts
+++ b/src/messaging/interface/verifier/response.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { CType, Credential, Did } from '@kiltprotocol/sdk-js'
 import { DidResolveKey, ICredential } from '@kiltprotocol/types'
 

--- a/src/messaging/utils.ts
+++ b/src/messaging/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/quote/Error.ts
+++ b/src/quote/Error.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/quote/Quote.test.ts
+++ b/src/quote/Quote.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 

--- a/src/quote/Quote.ts
+++ b/src/quote/Quote.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/quote/QuoteSchema.ts
+++ b/src/quote/QuoteSchema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/quote/index.ts
+++ b/src/quote/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/tests/messageUtils.ts
+++ b/src/tests/messageUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/types/Credential.ts
+++ b/src/types/Credential.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { DidUri } from '@kiltprotocol/types'
 import { VerifiableCredential, constants } from '@kiltprotocol/vc-export'
 

--- a/src/types/Imported.ts
+++ b/src/types/Imported.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import type {
   ICredential,
   ICredentialPresentation,

--- a/src/types/Quote.ts
+++ b/src/types/Quote.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { DecryptCallback, DidResourceUri, EncryptCallback, SignCallback } from '@kiltprotocol/types'
 
 import { IEncryptedMessage, IEncryptedMessageV1 } from './index.js'

--- a/src/types/Window.ts
+++ b/src/types/Window.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { DidResourceUri, KiltAddress } from '@kiltprotocol/types'
 import { HexString } from './Imported.js'
 import { CredentialDigestProof, SelfSignedProof } from '@kiltprotocol/vc-export'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/utils/TypeGuards.ts
+++ b/src/utils/TypeGuards.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { IAttestation, ICredentialPresentation, IRequestCredentialContent } from '@kiltprotocol/types'
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright (c) 2018-2023, Built on KILT.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * from './TypeGuards.js'

--- a/src/wellKnownDidConfiguration/index.ts
+++ b/src/wellKnownDidConfiguration/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/src/wellKnownDidConfiguration/wellKnownDidConfiguration.test.ts
+++ b/src/wellKnownDidConfiguration/wellKnownDidConfiguration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, BOTLabs GmbH.
+ * Copyright (c) 2018-2023, Built on KILT.
  *
  * This source code is licensed under the BSD 4-Clause "Original" license
  * found in the LICENSE file in the root directory of this source tree.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,13 @@ eslint-config-prettier@^9.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz#eb25485946dd0c66cd216a46232dc05451518d1f"
   integrity sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==
 
+eslint-plugin-license-header@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-license-header/-/eslint-plugin-license-header-0.6.0.tgz#81b0bab59da5a752d3a129f04bd0ca35bb6b07a2"
+  integrity sha512-IEywStBWaDBDMkogYoKUAdaOuomZ+YaQmdoSD2vHmXobekM+XuP6SWLlvwUUhIbdocn3MTlb5CUJ8E4VHz1c/w==
+  dependencies:
+    requireindex "^1.2.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -3938,6 +3945,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Updates the license and adds a lint rule so that the license headers in source files are kept up to date.

I'm using the license from the sdk repo here.